### PR TITLE
Fix typo in README section header from "Customizing" to "Customization"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Next, navigate to your project directory and install the dependencies:
 ```bash
 crewai install
 ```
-### Customizing
+### Customization
 
 **Required Configuration:**
 Add the following environment variables to your `.env` file:


### PR DESCRIPTION
I update a typo in the README.md file.